### PR TITLE
Added KeyCloak configurations to inventory and templates

### DIFF
--- a/inventory/host_vars/ci-cd-tooling.yml
+++ b/inventory/host_vars/ci-cd-tooling.yml
@@ -112,6 +112,20 @@ hoverfly:
     MEMORY_LIMIT: 2Gi
     HOVERFLY_IMAGE_STREAM_TAG: "{{ hoverfly_name }}:latest"
 
+keycloak_name: sso
+
+keycloak:
+  deploy:
+    NAME: "{{ keycloak_name }}"
+  dev:
+    NAME: "{{ keycloak_name }}"
+    REALM: dev
+  test:
+    NAME: "{{ keycloak_name }}"
+    REALM: test
+  demo:
+    NAME: "{{ keycloak_name }}"
+    REALM: demo
 
 openshift_cluster_content:
 - galaxy_requirements:
@@ -175,6 +189,37 @@ openshift_cluster_content:
     namespace: "{{ ci_cd_namespace }}"
     tags:
     - jenkins-slaves
+
+- object: keycloak
+  content:
+  - name: keycloak-server
+    template: "{{ inventory_dir }}/../templates/keycloak/deployment.yaml"
+    params_from_vars: "{{ keycloak.deploy }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - keycloak
+    - keycloak-deployment
+  - name: keycloak-dev
+    template: "{{ inventory_dir }}/../templates/keycloak/realm-client-user.yaml"
+    params_from_vars: "{{ keycloak.dev }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - keycloak
+    - keycloak-dev
+  - name: keycloak-test
+    template: "{{ inventory_dir }}/../templates/keycloak/realm-client-user.yaml"
+    params_from_vars: "{{ keycloak.test }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - keycloak
+    - keycloak-test
+  - name: keycloak-demo
+    template: "{{ inventory_dir }}/../templates/keycloak/realm-client-user.yaml"
+    params_from_vars: "{{ keycloak.demo }}"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - keycloak
+    - keycloak-demo
 
 # CI/CD Deployments is the OpenShift Deployment Configs and all
 # supporting tooling, pre and post hooks needed to setup and configure a comprehensive tool chain

--- a/inventory/host_vars/cluster-admin.yml
+++ b/inventory/host_vars/cluster-admin.yml
@@ -1,0 +1,14 @@
+---
+ansible_connection: local
+
+openshift_cluster_content:
+- object: keycloak-custom-resources
+  content:
+  - name: keycloak_crds
+    file: "{{ inventory_dir }}/../templates/keycloak/operator-crds.yaml"
+    namespace: "{{ ci_cd_namespace }}"
+    tags:
+    - operators
+    - keycloak
+    - keycloak-operator
+    - operator-crds

--- a/site.yml
+++ b/site.yml
@@ -5,14 +5,40 @@
     - include_role:
         name: openshift-applier/roles/openshift-applier
 
-- name: remove-limit-ranges-ci-cd
-  command: "oc delete limitrange -n {{ ci_cd_namespace }} {{ ci_cd_namespace }}-core-resource-limits"
-- name: remove-limit-ranges-dev
-  command: "oc delete limitrange -n {{ dev_namespace }} {{ dev_namespace }}-core-resource-limits"
-- name: remove-limit-ranges-test
-  command: "oc delete limitrange -n {{ test_namespace }} {{ test_namespace }}-core-resource-limits"
-- name: remove-limit-ranges-demo
-  command: "oc delete limitrange -n {{ demo_namespace }} {{ demo_namespace }}-core-resource-limits"
+- name: Remove limit ranges
+  hosts: bootstrap
+  tasks:
+  - name: remove-limit-ranges-ci-cd
+    command: "oc delete limitrange -n {{ ci_cd_namespace }} {{ ci_cd_namespace }}-core-resource-limits"
+  - name: remove-limit-ranges-dev
+    command: "oc delete limitrange -n {{ dev_namespace }} {{ dev_namespace }}-core-resource-limits"
+  - name: remove-limit-ranges-test
+    command: "oc delete limitrange -n {{ test_namespace }} {{ test_namespace }}-core-resource-limits"
+  - name: remove-limit-ranges-demo
+    command: "oc delete limitrange -n {{ demo_namespace }} {{ demo_namespace }}-core-resource-limits"
+
+- name: 'Deploy items which require elevated privileges in OpenShift'
+  hosts: cluster-admin
+  tasks:
+    - name: 'Check to see if CRDs are already created'
+      shell: oc get CustomResourceDefinition keycloaks.keycloak.org
+      register: are_keycloak_crds_present
+      ignore_errors: True
+    - name: 'Check for create/edit ClusterRoleBinding privilege'
+      shell: oc auth can-i create ClusterRoleBindings
+      register: cluster_role_bindings
+      ignore_errors: True
+    - name: 'Check for create/edit CustomResourceDefinition privilege'
+      shell: oc auth can-i create CustomResourceDefinition
+      register: custom_resource_definitions
+      ignore_errors: True
+    ## Only attempt to deploy KeyCloak Operator IF we have the correct rights AND it is not already deployed
+    - include_role:
+        name: openshift-applier/roles/openshift-applier
+      when:
+        are_keycloak_crds_present.rc != 0 and (cluster_role_bindings.rc + custom_resource_definitions.rc) == 0
+      tags:
+        - openshift-applier
 
 - name: Deploy CI/CD Tooling
   hosts: tools

--- a/templates/keycloak/deployment.yaml
+++ b/templates/keycloak/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Template
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+objects:
+- apiVersion: keycloak.org/v1alpha1
+  kind: Keycloak
+  metadata:
+    labels:
+      app: "${NAME}"
+    name: "${NAME}-keycloak"
+  spec:
+    extensions:
+    - https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
+    externalAccess:
+      enabled: true
+    instances: 1
+  status: {}
+parameters:
+- name: NAME
+  required: true
+  value: sso
+  required: true
+  displayName: Name
+  description: The name of the KeyCloak instance
+  apiVersion: v1

--- a/templates/keycloak/deployment.yaml
+++ b/templates/keycloak/deployment.yaml
@@ -4,6 +4,186 @@ metadata:
   resourceVersion: ""
   selfLink: ""
 objects:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    creationTimestamp: null
+    name: keycloak-operator
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - services
+    - services/finalizers
+    - endpoints
+    - persistentvolumeclaims
+    - events
+    - configmaps
+    - secrets
+    verbs:
+    - list
+    - get
+    - create
+    - patch
+    - update
+    - watch
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    - daemonsets
+    - replicasets
+    - statefulsets
+    verbs:
+    - list
+    - get
+    - create
+    - update
+    - watch
+  - apiGroups:
+    - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+    - route.openshift.io
+    resources:
+    - routes
+    verbs:
+    - list
+    - get
+    - create
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs:
+    - list
+    - get
+    - create
+    - update
+    - watch
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - servicemonitors
+    - prometheusrules
+    - podmonitors
+    verbs:
+    - list
+    - get
+    - create
+    - update
+    - watch
+  - apiGroups:
+    - integreatly.org
+    resources:
+    - grafanadashboards
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - watch
+  - apiGroups:
+    - apps
+    resourceNames:
+    - keycloak-operator
+    resources:
+    - deployments/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - policy
+    resources:
+    - poddisruptionbudgets
+    verbs:
+    - get
+    - list
+    - create
+    - update
+    - watch
+  - apiGroups:
+    - keycloak.org
+    resources:
+    - keycloaks
+    - keycloaks/status
+    - keycloaks/finalizers
+    - keycloakrealms
+    - keycloakrealms/status
+    - keycloakrealms/finalizers
+    - keycloakclients
+    - keycloakclients/status
+    - keycloakclients/finalizers
+    - keycloakbackups
+    - keycloakbackups/status
+    - keycloakbackups/finalizers
+    - keycloakusers
+    - keycloakusers/status
+    - keycloakusers/finalizers
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: keycloak-operator
+- kind: RoleBinding
+  apiVersion: rbac.authorization.k8s.io/v1
+  metadata:
+    name: keycloak-operator
+  subjects:
+  - kind: ServiceAccount
+    name: keycloak-operator
+  roleRef:
+    kind: Role
+    name: keycloak-operator
+    apiGroup: rbac.authorization.k8s.io
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: keycloak-operator
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        name: keycloak-operator
+    template:
+      metadata:
+        labels:
+          name: keycloak-operator
+      spec:
+        serviceAccountName: keycloak-operator
+        containers:
+          - name: keycloak-operator
+            # Replace this with the built image name
+            image: quay.io/keycloak/keycloak-operator:9.0.2
+            command:
+            - keycloak-operator
+            imagePullPolicy: Always
+            env:
+              - name: WATCH_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: OPERATOR_NAME
+                value: "keycloak-operator"
 - apiVersion: keycloak.org/v1alpha1
   kind: Keycloak
   metadata:
@@ -24,4 +204,3 @@ parameters:
   required: true
   displayName: Name
   description: The name of the KeyCloak instance
-  apiVersion: v1

--- a/templates/keycloak/operator-crds.yaml
+++ b/templates/keycloak/operator-crds.yaml
@@ -1,0 +1,1124 @@
+apiVersion: v1
+kind: List
+metadata:
+  description: "KeyCloak Operator Custom Resource Definitions"
+  resourceVersion: ""
+  selfLink: ""
+items:
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: keycloakbackups.keycloak.org
+  spec:
+    conversion:
+      strategy: None
+    group: keycloak.org
+    names:
+      kind: KeycloakBackup
+      listKind: KeycloakBackupList
+      plural: keycloakbackups
+      singular: keycloakbackup
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created
+                  on AWS S3 instead of a local Persistent Volume. If this property
+                  is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS
+                      S3 Service. The secret needs to be in the following form: \n
+                      \    apiVersion: v1     kind: Secret     metadata:       name:
+                      <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME:
+                      <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>
+                      \      AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information,
+                      please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted.
+                      Provides a secret name used for encrypting database data. The
+                      secret needs to be in the following form: \n     apiVersion:
+                      v1     kind: Secret     metadata:       name: <Secret name>
+                      \    type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG
+                      Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT:
+                      <GPG Recipient> \n For more information, please refer to the
+                      Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating
+                      a CronJob
+                    type: string
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented.
+                  \n In the future this will be used to trigger automatic restore
+                  for a given KeycloakBackup. Each backup will correspond to a single
+                  snapshot of the database (stored either in a Persistent Volume or
+                  AWS). If a user wants to restore it, all he/she needs to do is to
+                  change this flag to true. Potentially, it will be possible to restore
+                  a single backup multiple times."
+                type: boolean
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup
+            properties:
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  status: {}
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: keycloakclients.keycloak.org
+  spec:
+    conversion:
+      strategy: None
+    group: keycloak.org
+    names:
+      kind: KeycloakClient
+      listKind: KeycloakClientList
+      plural: keycloakclients
+      singular: keycloakclient
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create
+                      a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  status: {}
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: keycloakrealms.keycloak.org
+  spec:
+    conversion:
+      strategy: None
+    group: keycloak.org
+    names:
+      kind: KeycloakRealm
+      listKind: KeycloakRealmList
+      plural: keycloakrealms
+      singular: keycloakrealm
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values
+                      and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and
+                      use kubebuilder default annotation once supported'
+                    type: boolean
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel
+                            logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically
+                            generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically
+                            create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and
+                      use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    type: string
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity
+                            Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  realm:
+                    description: Realm name.
+                    type: string
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  status: {}
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: keycloaks.keycloak.org
+  spec:
+    conversion:
+      strategy: None
+    group: keycloak.org
+    names:
+      kind: Keycloak
+      listKind: KeycloakList
+      plural: keycloaks
+      singular: keycloak
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak
+            properties:
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR
+                  files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress
+                      or a Route pointing to Keycloak.
+                    type: boolean
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external
+                  database requires providing a secret containing credentials as well
+                  as connection details. Here's an example of such secret: \n     apiVersion:
+                  v1     kind: Secret     metadata:         name: keycloak-db-secret
+                  \        namespace: keycloak     stringData:         POSTGRES_DATABASE:
+                  <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database
+                  IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External
+                  Database Port>         # Strongly recommended to use <'Keycloak
+                  CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>
+                  \        POSTGRES_PASSWORD: <Database Password>         # Required
+                  for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME:
+                  <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS
+                  and POSTGRES_EXTERNAL_PORT are specifically required for creating
+                  connection to the external database. The secret name is created
+                  using the following convention:       <Custom Resource Name>-db-secret
+                  \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external
+                      database. pointing to Keycloak.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget
+                      for the Keycloak deployment and set its `maxUnavailable` value
+                      to 1
+                    type: boolean
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default
+                  is empty.
+                type: string
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found
+                type: string
+              internalURL:
+                description: Service IP and Port for in-cluster access to the keycloak
+                  instance
+                type: string
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work
+                  is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names
+                  created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2"
+                  ]'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  status: {}
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: keycloakusers.keycloak.org
+  spec:
+    conversion:
+      strategy: None
+    group: keycloak.org
+    names:
+      kind: KeycloakUser
+      listKind: KeycloakUserList
+      plural: keycloakusers
+      singular: keycloakuser
+    scope: Namespaced
+    subresources:
+      status: {}
+    validation:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser
+            properties:
+              message:
+                description: Human-readable message indicating details about current
+                  operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    version: v1alpha1
+    versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  status: {}

--- a/templates/keycloak/realm-client-user.yaml
+++ b/templates/keycloak/realm-client-user.yaml
@@ -1,0 +1,118 @@
+apiVersion: v1
+kind: Template
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+objects:
+- apiVersion: keycloak.org/v1alpha1
+  kind: KeycloakRealm
+  metadata:
+    finalizers:
+    - realm.cleanup
+    generation: 1
+    labels:
+      app: "${NAME}"
+      realm: "${REALM}"
+    name: "keycloak-realm-${REALM}"
+  spec:
+    instanceSelector:
+      matchLabels:
+        app: "${NAME}"
+    realm:
+      displayName: "${REALM} Environment Realm"
+      enabled: true
+      id: "${REALM}"
+      realm: "${REALM}"
+  status: {}
+- apiVersion: keycloak.org/v1alpha1
+  kind: KeycloakClient
+  metadata:
+    name: "${REALM}-client-secret"
+    labels:
+      realm: "${REALM}"
+  spec:
+    realmSelector:
+      matchLabels:
+        realm: "${REALM}"
+    client:
+      clientId: "${CLIENT_ID}"
+      secret: "${CLIENT_SECRET}"
+      clientAuthenticatorType: client-secret
+- apiVersion: keycloak.org/v1alpha1
+  kind: KeycloakUser
+  metadata:
+    finalizers:
+    - user.cleanup
+    generation: 4
+    labels:
+      app: "${NAME}"
+    name: "realm-${REALM}-user-jqconsultant"
+  spec:
+    realmSelector:
+      matchLabels:
+        realm: "${REALM}"
+    user:
+      clientRoles:
+        account:
+        - manage-account
+        realm-management:
+        - manage-users
+      credentials:
+      - type: password
+        value: letmein
+      email: jqconsultant@redhat.com
+      emailVerified: true
+      enabled: true
+      firstName: John
+      lastName: Consultant
+      realmRoles:
+      - offline_access
+      username: jqconsultant
+  status: {}
+- apiVersion: keycloak.org/v1alpha1
+  kind: KeycloakUser
+  metadata:
+    finalizers:
+    - user.cleanup
+    generation: 4
+    labels:
+      app: "${NAME}"
+    name: "realm-${REALM}-user-jpmanager"
+  spec:
+    realmSelector:
+      matchLabels:
+        realm: "${REALM}"
+    user:
+      clientRoles:
+        account:
+        - manage-account
+        realm-management:
+        - manage-users
+      credentials:
+      - type: password
+        value: letmein
+      email: jpmanager@redhat.com
+      emailVerified: true
+      enabled: true
+      firstName: Jane
+      lastName: Manager
+      realmRoles:
+      - offline_access
+      username: jpmanager
+  status: {}
+parameters:
+- name: NAME
+  required: true
+  value: sso
+  displayName: Name
+  description: The name of the KeyCloak instance
+- name: REALM
+  required: true
+  description: The name of the KeyCloak Realm
+  displayNam: Realm
+- name: CLIENT_ID
+  required: true
+  value: consultant360
+- name: CLIENT_SECRET
+  generate: expression
+  from: "[a-z0-9]{24}"

--- a/templates/keycloak/realm-client-user.yaml
+++ b/templates/keycloak/realm-client-user.yaml
@@ -98,6 +98,7 @@ objects:
       lastName: Manager
       realmRoles:
       - offline_access
+      - project_manager
       username: jpmanager
   status: {}
 parameters:


### PR DESCRIPTION
This change adds some new templates and new host_vars to allow for deployment of:

- 1 KeyCloak Operator in the `ci_cd` nameapace
- 1 KeyCloak server in the `ci_cd` namespace
- 3 KeyCloak REALMS, one for each deployment namespace
- 3 KeyCloak client configurations, one for each deployment namespace
- 6 KeyCloak users (1 consultant and 1 PM per deployment namespace)

Resolves APPDEVCOLL-17